### PR TITLE
module-efs

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,12 +27,18 @@ module "networking" {
   sysadmin_cidr = var.sysadmin_cidr
 }
 
+module "aws-efs" {
+  source = "./modules/aws-efs"
+  project_name = var.project_name
+  subnet_ids = module.networking.subnet_private_ids
+}
+
+
 resource "aws_db_subnet_group" "wordpress" {
   name       = "${var.project_name}_wordpress"
   subnet_ids = module.networking.subnet_private_ids
 }
 
->>>>>>> master
 resource "aws_db_instance" "mysql-wordpress" {
   allocated_storage         = 20
   identifier                = "db-wordpress"

--- a/terraform/modules/aws-efs/main.tf
+++ b/terraform/modules/aws-efs/main.tf
@@ -1,0 +1,14 @@
+resource "aws_efs_file_system" "project_1" {
+  creation_token = "wordpress"
+  encrypted ="false"
+
+  tags = {
+    Name = var.project_name
+  }
+}
+
+resource "aws_efs_mount_target" "project_1" {
+  count          = length(var.subnet_ids)
+  subnet_id      = var.subnet_ids[count.index]
+  file_system_id = aws_efs_file_system.project_1.id
+}

--- a/terraform/modules/aws-efs/output.tf
+++ b/terraform/modules/aws-efs/output.tf
@@ -1,0 +1,3 @@
+output "id" {
+    value = aws_efs_file_system.project_1.id
+}

--- a/terraform/modules/aws-efs/variables.tf
+++ b/terraform/modules/aws-efs/variables.tf
@@ -1,0 +1,7 @@
+variable "project_name" {
+  type = string
+}
+
+variable "subnet_ids" {
+  type = list
+}


### PR DESCRIPTION
EFS module integrated getting private subnet ids from module networking

done:
- [x] use vpc from network stack
- [x] at least one mount target (AZ)
- [ ] security group allowing only ECS instances to access it
- [x] no lifecycle policy
- [x] throughput mode bursting
- [x] performance mode general purpose
- [x] no need for encryption
- [x] no need for IAM authentication
add one access point:
name wordpress
path /wordpress

Close #18 