### PR TITLE
initial cloudwatch implementation

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,5 @@ AWS_PROFILE
 TF_VAR_project_name=wdpress-dev
 TF_VAR_db_username=admin
 TF_VAR_db_password=test1234
+TF_VAR_alert_sms=+614xxxxxxxx
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -60,3 +60,10 @@ module "aurora-db" {
     timeout_action           = "ForceApplyCapacityChange"
   }
 }
+
+module "cloudwatch" {
+  source         = "./modules/aws-cloudwatch"
+  project_name   = var.project_name
+  alert_sms      = var.alert_sms
+  rds_cluster_id = module.aurora-db.cluster_identifier
+}

--- a/terraform/modules/aws-cloudwatch/notification.tf
+++ b/terraform/modules/aws-cloudwatch/notification.tf
@@ -1,0 +1,9 @@
+resource "aws_sns_topic" "alerts" {
+  name = "${var.project_name}_cloudwatch-alerts"
+}
+
+resource "aws_sns_topic_subscription" "sms" {
+  topic_arn = aws_sns_topic.alerts.arn
+  protocol  = "sms"
+  endpoint  = var.alert_sms
+}

--- a/terraform/modules/aws-cloudwatch/rds.tf
+++ b/terraform/modules/aws-cloudwatch/rds.tf
@@ -1,0 +1,19 @@
+resource "aws_cloudwatch_metric_alarm" "rds" {
+  alarm_name          = "${var.project_name}_rds_cpu"
+  alarm_description   = "Alerts if the RDS CPU usage is high"
+  namespace           = "AWS/RDS"
+  metric_name         = "CPUUtilization"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  statistic           = "Average"
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  period              = 60
+  threshold           = 70
+  treat_missing_data  = "breaching"
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    DBClusterIdentifier = var.rds_cluster_id
+  }
+}

--- a/terraform/modules/aws-cloudwatch/variables.tf
+++ b/terraform/modules/aws-cloudwatch/variables.tf
@@ -1,0 +1,14 @@
+variable "project_name" {
+  type = string
+  description = "Project name to be used when naming resources."
+}
+
+variable "alert_sms" {
+  type = string
+  description = "Mobile number that will receive alerts, example: +614xxxxxxxx"
+}
+
+variable "rds_cluster_id" {
+  type = string
+  description = "RDS cluster to monitor"
+}

--- a/terraform/modules/aws-rds/output.tf
+++ b/terraform/modules/aws-rds/output.tf
@@ -23,3 +23,7 @@ output "default_rds_cluster_reader_endpoint" {
   description = "The cluster reader endpoint"
   value       = aws_rds_cluster.default.reader_endpoint
 }
+
+output "cluster_identifier" {
+  value = aws_rds_cluster.default.cluster_identifier
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -21,3 +21,8 @@ variable "cidr_vpc" {
   description = "CIDR block for the VPC"
   default     = "10.10.0.0/16"
 }
+
+variable "alert_sms" {
+  type = string
+  description = "Mobile number that will receive cloudwatch alerts, example: +614xxxxxxxx"
+}


### PR DESCRIPTION
I couldn't test the alarm itself because the database is not being used. 
I could try to find a way to work around it but I think it's easier to wait until WP is working. 
For now it only monitor RDS' CPU but once we have a load balancer, we can monitor it too